### PR TITLE
Use Popen instead of check_call in collect_tests

### DIFF
--- a/pytest_bisect_tests/pytest_runner.py
+++ b/pytest_bisect_tests/pytest_runner.py
@@ -25,7 +25,7 @@ class PytestRunner:
         r, w = os.pipe()
         os.set_inheritable(w, True)
         try:
-            subprocess.check_call(
+            process = subprocess.Popen(
                 [
                     "pytest",
                     "--collect-only",
@@ -40,7 +40,10 @@ class PytestRunner:
             )
             os.close(w)
             with os.fdopen(r, closefd=False) as f:
-                return [l.strip() for l in f.readlines()]
+                tests = [l.strip() for l in f.readlines()]
+            if process.wait() != 0:
+                raise RuntimeError("Failed to collect tests.")
+            return tests
         finally:
             os.closerange(r, w)
 


### PR DESCRIPTION
`check_call` is blocking, and if the list of collected tests exceeds the system's pipe-max-size, pushing to the pipe will also block until data is pulled off of it. This means that the `check_call` call will never return and hang forever.

Using `Popen` instead allows the code after the subprocess call to execute immediately, and it will block reading until the pipe gets closed from the other end.